### PR TITLE
Rename values method to appsLoad

### DIFF
--- a/src/Livewire/AppsLoad.php
+++ b/src/Livewire/AppsLoad.php
@@ -24,14 +24,14 @@ class AppsLoad extends Card
     public function render(): View
     {
         return ViewFacace::make('apps-load::livewire.card', [
-            'apps' => $this->apps($this->values()),
+            'apps' => $this->apps($this->appsLoad()),
         ]);
     }
 
     /**
      * @return array
      */
-    protected function values(): array
+    protected function appsLoad(): array
     {
         return ($values = Pulse::values('apps-load', ['result'])->first())
             ? json_decode($values->value, true, JSON_THROW_ON_ERROR)


### PR DESCRIPTION
This PR renames the `values` method to `appsLoad`, as in Pulse v1.0.0-beta8, we have a `values` method in `Card` component with a different signature and causes error.